### PR TITLE
feat(reporters) Markdown File Summary Reporter

### DIFF
--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -102,10 +102,10 @@ dotnet stryker --reporter "json"
 ```
 
 # Markdown summary reporter
-This reporter outputs a Markdown formatted summary file based on the output of the `ClearTextReporter`.  
+This reporter outputs a Markdown formatted summary file called `mutation-report.md` in the `StrykerOutput/{date-time}/reports` directory based on the output of the `ClearTextReporter`.  
 
 ```bash
-dotnet stryker --reporter "markdownsummary"
+dotnet stryker --reporter "markdown"
 ```
 
 Example:

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -112,7 +112,7 @@ Example:
 
 # Mutation Testing Summary
 
-| File                                                        | Score   | Killed | Survived | Timeout | No Coverage | Ingnored | Compile Errors | Total Detected | Total Undetected | Total Mutants |
+| File                                                        | Score   | Killed | Survived | Timeout | No Coverage | Ignored | Compile Errors | Total Detected | Total Undetected | Total Mutants |
 | ----------------------------------------------------------- | ------- | ------ | -------- | ------- | ----------- | -------- | -------------- | -------------- | ---------------- | ------------- |
 | Utils\\Extensions.cs      | 76.74%  | 66     | 14       | 0       | 6           | 9        | 0              | 66             | 20               | 95            |
 | Entities\\Entity1.cs     | N\/A    | 0      | 0        | 0       | 0           | 0        | 0              | 0              | 0                | 0             |

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -100,3 +100,22 @@ This reporter outputs a json file with all mutation testrun info of the last run
 ```bash
 dotnet stryker --reporter "json"
 ```
+
+# Markdown summary reporter
+This reporter outputs a Markdown formatted summary file based on the output of the `ClearTextReporter`.  
+
+```bash
+dotnet stryker --reporter "markdownsummary"
+```
+
+Example:
+
+## Mutation Testing Summary
+
+| File                                                        | % score | \# killed | \# timeout | \# survived | \# no cov | \# error |
+| ----------------------------------------------------------- | ------- | --------- | ---------- | ----------- | --------- | -------- |
+| Entities\\Entity1.cs                          | 100.00  | 1         | 0          | 3           | 0         | 2        |
+| Program.cs                                                  | N\/A    | 0         | 0          | 6           | 0         | 0        |
+| Utils\\EntityExtensions.cs                       | 87.50   | 7         | 0          | 1           | 1         | 0        |
+
+#### *Coverage Thresholds: high:90 low:60 break:60*

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -112,12 +112,12 @@ Example:
 
 # Mutation Testing Summary
 
-| File                                                        | % score | \# killed | \# timeout | \# survived | \# no cov | \# error |
-| ----------------------------------------------------------- | ------- | --------- | ---------- | ----------- | --------- | -------- |
-| Entities\\Entity1.cs                          | 100.00  | 1         | 0          | 3           | 0         | 2        |
-| Program.cs                                                  | N\/A    | 0         | 0          | 6           | 0         | 0        |
-| Utils\\LoggerUtils.cs | 84.62   | 11        | 0          | 2           | 0         | 0        |
+| File                                                        | Score   | Killed | Survived | Timeout | No Coverage | Ingnored | Compile Errors | Total Detected | Total Undetected | Total Mutants |
+| ----------------------------------------------------------- | ------- | ------ | -------- | ------- | ----------- | -------- | -------------- | -------------- | ---------------- | ------------- |
+| Utils\\Extensions.cs      | 76.74%  | 66     | 14       | 0       | 6           | 9        | 0              | 66             | 20               | 95            |
+| Entities\\Entity1.cs     | N\/A    | 0      | 0        | 0       | 0           | 0        | 0              | 0              | 0                | 0             |
+| Program.cs                        | 87.50%  | 7      | 0        | 0       | 1           | 0        | 0              | 7              | 1                | 8             |
 
-## The final mutation score is 93.70%
+## The final mutation score is 78.70%
 
 ### *Coverage Thresholds: high:90 low:60 break:60*

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -102,7 +102,7 @@ dotnet stryker --reporter "json"
 ```
 
 # Markdown summary reporter
-This reporter outputs a Markdown formatted summary file called `mutation-report.md` (by default) in the `StrykerOutput/{date-time}/reports` directory.  The output is heavily based on the output of the `ClearTextReporter`.  
+This reporter outputs a Markdown formatted summary file called `mutation-report.md` (by default) in the `StrykerOutput/{date-time}/reports` directory.  
 
 ```bash
 dotnet stryker --reporter "markdown"

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -110,12 +110,14 @@ dotnet stryker --reporter "markdown"
 
 Example:
 
-## Mutation Testing Summary
+# Mutation Testing Summary
 
 | File                                                        | % score | \# killed | \# timeout | \# survived | \# no cov | \# error |
 | ----------------------------------------------------------- | ------- | --------- | ---------- | ----------- | --------- | -------- |
 | Entities\\Entity1.cs                          | 100.00  | 1         | 0          | 3           | 0         | 2        |
 | Program.cs                                                  | N\/A    | 0         | 0          | 6           | 0         | 0        |
-| Utils\\EntityExtensions.cs                       | 87.50   | 7         | 0          | 1           | 1         | 0        |
+| Utils\\LoggerUtils.cs | 84.62   | 11        | 0          | 2           | 0         | 0        |
 
-#### *Coverage Thresholds: high:90 low:60 break:60*
+## The final mutation score is 93.70%
+
+### *Coverage Thresholds: high:90 low:60 break:60*

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -102,7 +102,7 @@ dotnet stryker --reporter "json"
 ```
 
 # Markdown summary reporter
-This reporter outputs a Markdown formatted summary file called `mutation-report.md` in the `StrykerOutput/{date-time}/reports` directory based on the output of the `ClearTextReporter`.  
+This reporter outputs a Markdown formatted summary file called `mutation-report.md` (by default) in the `StrykerOutput/{date-time}/reports` directory.  The output is heavily based on the output of the `ClearTextReporter`.  
 
 ```bash
 dotnet stryker --reporter "markdown"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <MicrosoftTestPlatform>17.2.0</MicrosoftTestPlatform>
-    <SystemIOAbstractions>17.0.24</SystemIOAbstractions>
+    <SystemIOAbstractions>17.1.1</SystemIOAbstractions>
     <MicrosoftExtensionsConfiguration>6.0.0</MicrosoftExtensionsConfiguration>
   </PropertyGroup>
 

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/packages.lock.json
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/packages.lock.json
@@ -156,6 +156,11 @@
         "resolved": "5.0.0",
         "contentHash": "iHoYXA0VaSQUONGENB1aVafjDDZDZpwu39MtaRCTrmwFW/cTcK0b2yKNVYneFHJMc3ChtsSoM9lNtJ1dYXkHfA=="
       },
+      "Grynwald.MarkdownGenerator": {
+        "type": "Transitive",
+        "resolved": "2.5.34",
+        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+      },
       "LibGit2Sharp": {
         "type": "Transitive",
         "resolved": "0.27.0-preview-0182",
@@ -1644,6 +1649,7 @@
           "Buildalyzer": "[4.1.4, )",
           "DotNet.Glob": "[3.1.3, )",
           "FSharp.Compiler.Service": "[38.0.0, )",
+          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "LibGit2Sharp": "[0.27.0-preview-0182, )",
           "Microsoft.CodeAnalysis.CSharp": "[4.2.0, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
@@ -1663,8 +1669,8 @@
           "ShellProgressBar": "[5.2.0, )",
           "Spectre.Console": "[0.44.0, )",
           "Spectre.Console.Analyzer": "[0.44.0, )",
-          "Stryker.DataCollector": "[2.1.2, )",
-          "Stryker.RegexMutators": "[2.1.2, )",
+          "Stryker.DataCollector": "[1.0.0, )",
+          "Stryker.RegexMutators": "[1.0.0, )",
           "System.IO.Abstractions": "[17.0.24, )",
           "System.Net.Http.Json": "[6.0.0, )"
         }

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/packages.lock.json
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/packages.lock.json
@@ -68,11 +68,11 @@
       },
       "System.IO.Abstractions.TestingHelpers": {
         "type": "Direct",
-        "requested": "[17.0.24, )",
-        "resolved": "17.0.24",
-        "contentHash": "PePTkh5aFsCWSUmc3msyRdJS+aJ15DZDmhgnnjuR7lBSfEyeOi3+CfQqpU28+lpmLH1tFv16K2ODcUNg7lzOPA==",
+        "requested": "[17.1.1, )",
+        "resolved": "17.1.1",
+        "contentHash": "IXsc9skbI+xsjgfsIH5xTdXN/QUyeBc1WVjiJ+IwOthFakBZmN2bqwPH/tYX0FeOEzJ6ZfrZyhqdJ/B+rPHLEQ==",
         "dependencies": {
-          "System.IO.Abstractions": "17.0.24"
+          "System.IO.Abstractions": "17.1.1"
         }
       },
       "xunit": {
@@ -1062,8 +1062,8 @@
       },
       "System.IO.Abstractions": {
         "type": "Transitive",
-        "resolved": "17.0.24",
-        "contentHash": "hA7bacntMiZv1Yf9xtjwl/GP3GT1mG84QxhAk7ijAUD0pJhJaVVwXScE13vMpXnNtlaRDW6SeyZdWg2j2qrh4w=="
+        "resolved": "17.1.1",
+        "contentHash": "LWOM12Bd0kp/gaH4g1o/O2/6JDcHF/fuctF1IqDZt0aAqU2BwGiMihi9Cdcm5jJz8La1wFWbRPuRui8WeX6m8w=="
       },
       "System.IO.FileSystem": {
         "type": "Transitive",
@@ -1665,7 +1665,7 @@
           "Spectre.Console.Analyzer": "[0.44.0, )",
           "Stryker.DataCollector": "[2.1.2, )",
           "Stryker.RegexMutators": "[2.1.2, )",
-          "System.IO.Abstractions": "[17.0.24, )",
+          "System.IO.Abstractions": "[17.1.1, )",
           "System.Net.Http.Json": "[6.0.0, )"
         }
       },

--- a/src/Stryker.CLI/Stryker.CLI/packages.lock.json
+++ b/src/Stryker.CLI/Stryker.CLI/packages.lock.json
@@ -736,8 +736,8 @@
       },
       "System.IO.Abstractions": {
         "type": "Transitive",
-        "resolved": "17.0.24",
-        "contentHash": "hA7bacntMiZv1Yf9xtjwl/GP3GT1mG84QxhAk7ijAUD0pJhJaVVwXScE13vMpXnNtlaRDW6SeyZdWg2j2qrh4w=="
+        "resolved": "17.1.1",
+        "contentHash": "LWOM12Bd0kp/gaH4g1o/O2/6JDcHF/fuctF1IqDZt0aAqU2BwGiMihi9Cdcm5jJz8La1wFWbRPuRui8WeX6m8w=="
       },
       "System.IO.FileSystem": {
         "type": "Transitive",
@@ -1161,7 +1161,7 @@
           "Spectre.Console.Analyzer": "[0.44.0, )",
           "Stryker.DataCollector": "[2.1.2, )",
           "Stryker.RegexMutators": "[2.1.2, )",
-          "System.IO.Abstractions": "[17.0.24, )",
+          "System.IO.Abstractions": "[17.1.1, )",
           "System.Net.Http.Json": "[6.0.0, )"
         }
       },

--- a/src/Stryker.CLI/Stryker.CLI/packages.lock.json
+++ b/src/Stryker.CLI/Stryker.CLI/packages.lock.json
@@ -89,6 +89,11 @@
         "resolved": "5.0.0",
         "contentHash": "iHoYXA0VaSQUONGENB1aVafjDDZDZpwu39MtaRCTrmwFW/cTcK0b2yKNVYneFHJMc3ChtsSoM9lNtJ1dYXkHfA=="
       },
+      "Grynwald.MarkdownGenerator": {
+        "type": "Transitive",
+        "resolved": "2.5.34",
+        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+      },
       "LibGit2Sharp": {
         "type": "Transitive",
         "resolved": "0.27.0-preview-0182",
@@ -1140,6 +1145,7 @@
           "Buildalyzer": "[4.1.4, )",
           "DotNet.Glob": "[3.1.3, )",
           "FSharp.Compiler.Service": "[38.0.0, )",
+          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "LibGit2Sharp": "[0.27.0-preview-0182, )",
           "Microsoft.CodeAnalysis.CSharp": "[4.2.0, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
@@ -1159,8 +1165,8 @@
           "ShellProgressBar": "[5.2.0, )",
           "Spectre.Console": "[0.44.0, )",
           "Spectre.Console.Analyzer": "[0.44.0, )",
-          "Stryker.DataCollector": "[2.1.2, )",
-          "Stryker.RegexMutators": "[2.1.2, )",
+          "Stryker.DataCollector": "[1.0.0, )",
+          "Stryker.RegexMutators": "[1.0.0, )",
           "System.IO.Abstractions": "[17.0.24, )",
           "System.Net.Http.Json": "[6.0.0, )"
         }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/DashboardBaselineProviderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/DashboardBaselineProviderTests.cs
@@ -38,7 +38,7 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
 
             var target = new DashboardBaselineProvider(strykerOptions, dashboardClient.Object);
 
-            await target.Save(JsonReport.Build(strykerOptions, JsonReportTestHelper.CreateProjectWith()), "version");
+            await target.Save(JsonReport.Build(strykerOptions, ReportTestHelper.CreateProjectWith()), "version");
 
             dashboardClient.Verify(x => x.PublishReport(It.IsAny<JsonReport>(), It.Is<string>(x => x == "version")), Times.Once);
         }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/DiskBaselineProviderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/DiskBaselineProviderTests.cs
@@ -23,7 +23,7 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
             var sut = new DiskBaselineProvider(options, fileSystemMock);
 
             // Act
-            await sut.Save(JsonReport.Build(options, JsonReportTestHelper.CreateProjectWith()), "baseline/version");
+            await sut.Save(JsonReport.Build(options, ReportTestHelper.CreateProjectWith()), "baseline/version");
 
             // Assert
             var path = FilePathUtils.NormalizePathSeparators(@"C:/Users/JohnDoe/Project/TestFolder/StrykerOutput/baseline/version/stryker-report.json");
@@ -55,7 +55,7 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
             {
                 ProjectPath = @"C:/Users/JohnDoe/Project/TestFolder"
             };
-            var report = JsonReport.Build(options, JsonReportTestHelper.CreateProjectWith());
+            var report = JsonReport.Build(options, ReportTestHelper.CreateProjectWith());
 
             fileSystemMock.AddFile("C:/Users/JohnDoe/Project/TestFolder/StrykerOutput/baseline/version/stryker-report.json", report.ToJson());
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Buildalyzer;
 using Microsoft.CodeAnalysis;
 using Mono.Collections.Generic;
@@ -10,8 +11,10 @@ using Stryker.Core.TestRunners;
 using System.Collections.Generic;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Stryker.Core.Mutants;
 using Xunit;
+using Shouldly;
 
 namespace Stryker.Core.UnitTest.Initialisation
 {
@@ -117,6 +120,115 @@ namespace Stryker.Core.UnitTest.Initialisation
             inputFileResolverMock.Verify(x => x.ResolveInput(It.IsAny<StrykerOptions>()), Times.Once);
             assemblyReferenceResolverMock.Verify();
             initialTestProcessMock.Verify(x => x.InitialTest(It.IsAny<StrykerOptions>(),testRunnerMock.Object), Times.Once);
+        }
+
+
+        [Fact]
+        public void InitialisationProcess_ShouldRunTestSession()
+        {
+            var testRunnerMock = new Mock<ITestRunner>(MockBehavior.Strict);
+            var inputFileResolverMock = new Mock<IInputFileResolver>(MockBehavior.Strict);
+            var initialBuildProcessMock = new Mock<IInitialBuildProcess>(MockBehavior.Strict);
+            var initialTestProcessMock = new Mock<IInitialTestProcess>(MockBehavior.Strict);
+            var assemblyReferenceResolverMock = new Mock<IAssemblyReferenceResolver>(MockBehavior.Strict);
+
+            var folder = new CsharpFolderComposite();
+            folder.Add(new CsharpFileLeaf());
+
+            inputFileResolverMock.Setup(x => x.ResolveInput(It.IsAny<StrykerOptions>())).Returns(
+                new ProjectInfo(new MockFileSystem())
+                {
+                    ProjectUnderTestAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
+                        references: new string[0]).Object,
+                    TestProjectAnalyzerResults = new List<IAnalyzerResult> { TestHelper.SetupProjectAnalyzerResult(
+                        projectFilePath: "C://Example/Dir/ProjectFolder",
+                        targetFramework: "netcoreapp2.1").Object
+                    },
+                    ProjectContents = folder
+                });
+
+            initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), null));
+            var testSet = new TestSet();
+            testSet.RegisterTest(new TestDescription(Guid.Empty, "test", "test.cs"));
+            testRunnerMock.Setup(x => x.DiscoverTests()).Returns(testSet);
+            initialTestProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>(),It.IsAny<ITestRunner>()))
+                .Returns(new InitialTestRun(new TestRunResult(true), null)); // failing test
+            assemblyReferenceResolverMock.Setup(x => x.LoadProjectReferences(It.IsAny<string[]>()))
+                .Returns(Enumerable.Empty<PortableExecutableReference>())
+                .Verifiable();
+
+            var target = new InitialisationProcess(
+                inputFileResolverMock.Object,
+                initialBuildProcessMock.Object,
+                initialTestProcessMock.Object,
+                testRunnerMock.Object,
+                assemblyReferenceResolverMock.Object);
+            var options = new StrykerOptions
+            {
+                ProjectName = "TheProjectName",
+                ProjectVersion = "TheProjectVersion"
+            };
+
+            target.Initialize(options);
+            target.InitialTest(options);
+
+            inputFileResolverMock.Verify(x => x.ResolveInput(It.IsAny<StrykerOptions>()), Times.Once);
+            assemblyReferenceResolverMock.Verify();
+            initialTestProcessMock.Verify(x => x.InitialTest(It.IsAny<StrykerOptions>(),testRunnerMock.Object), Times.Once);
+        }
+
+
+        [Theory]
+        [InlineData("xunit.core")]
+        [InlineData("nunit.framework")]
+        [InlineData("Microsoft.VisualStudio.TestPlatform.TestFramework")]
+        [InlineData("")]
+        public void InitialisationProcess_ShouldThrowOnWhenNoTestDetected(string libraryName)
+        {
+            var testRunnerMock = new Mock<ITestRunner>(MockBehavior.Strict);
+            var inputFileResolverMock = new Mock<IInputFileResolver>(MockBehavior.Strict);
+            var initialBuildProcessMock = new Mock<IInitialBuildProcess>(MockBehavior.Strict);
+            var initialTestProcessMock = new Mock<IInitialTestProcess>(MockBehavior.Strict);
+            var assemblyReferenceResolverMock = new Mock<IAssemblyReferenceResolver>(MockBehavior.Strict);
+
+            var folder = new CsharpFolderComposite();
+            folder.Add(new CsharpFileLeaf());
+
+            inputFileResolverMock.Setup(x => x.ResolveInput(It.IsAny<StrykerOptions>())).Returns(
+                new ProjectInfo(new MockFileSystem())
+                {
+                    ProjectUnderTestAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
+                        references: new string[0]).Object,
+                    TestProjectAnalyzerResults = new List<IAnalyzerResult> { TestHelper.SetupProjectAnalyzerResult(
+                        projectFilePath: "C://Example/Dir/ProjectFolder",
+                        targetFramework: "netcoreapp2.1",
+                        references: new[] { libraryName}).Object
+                    },
+                    ProjectContents = folder
+                });
+
+            initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), null));
+            testRunnerMock.Setup(x => x.DiscoverTests()).Returns(new TestSet());
+            initialTestProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<ITestRunner>()))
+                .Returns(new InitialTestRun(new TestRunResult(true), null)); // failing test
+            assemblyReferenceResolverMock.Setup(x => x.LoadProjectReferences(It.IsAny<string[]>()))
+                .Returns(Enumerable.Empty<PortableExecutableReference>())
+                .Verifiable();
+
+            var target = new InitialisationProcess(
+                inputFileResolverMock.Object,
+                initialBuildProcessMock.Object,
+                initialTestProcessMock.Object,
+                testRunnerMock.Object,
+                assemblyReferenceResolverMock.Object);
+            var options = new StrykerOptions
+            {
+                ProjectName = "TheProjectName",
+                ProjectVersion = "TheProjectVersion"
+            };
+
+            target.Initialize(options);
+            Assert.Throws<InputException>(() => target.InitialTest(options)).Message.ShouldContain(libraryName);
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/ReportersInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/ReportersInputTests.cs
@@ -13,7 +13,7 @@ namespace Stryker.Core.UnitTest.Options.Inputs
         public void ShouldHaveHelpText()
         {
             var target = new ReportersInput();
-            target.HelpText.ShouldBe("Reporters inform about various stages in the mutation testrun. | default: ['Progress', 'Html'] | allowed: All, Progress, Dots, ClearText, ClearTextTree, Json, Html, Dashboard, Baseline");
+            target.HelpText.ShouldBe("Reporters inform about various stages in the mutation testrun. | default: ['Progress', 'Html'] | allowed: All, Progress, Dots, ClearText, ClearTextTree, Json, Html, Dashboard, Markdown, Baseline");
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/DashboardReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/DashboardReporterTests.cs
@@ -36,7 +36,7 @@ namespace Stryker.Core.UnitTest.Reporters
             var target = new DashboardReporter(options, dashboardClient: dashboardClientMock.Object, processWrapper: mockProcess.Object);
 
             // Act
-            target.OnAllMutantsTested(JsonReportTestHelper.CreateProjectWith());
+            target.OnAllMutantsTested(ReportTestHelper.CreateProjectWith());
 
             // Assert
             dashboardClientMock.Verify(x => x.PublishReport(It.IsAny<JsonReport>(), "version/human/readable"), Times.Once);
@@ -61,7 +61,7 @@ namespace Stryker.Core.UnitTest.Reporters
                 .Returns(Task.FromResult("https://dashboard.com"));
 
             var reporter = new DashboardReporter(options, dashboardClientMock.Object, processWrapper: mockProcess.Object);
-            var mutationTree = JsonReportTestHelper.CreateProjectWith();
+            var mutationTree = ReportTestHelper.CreateProjectWith();
 
             reporter.OnAllMutantsTested(mutationTree);
 
@@ -90,7 +90,7 @@ namespace Stryker.Core.UnitTest.Reporters
                 .Returns(Task.FromResult("https://dashboard.com"));
 
             var reporter = new DashboardReporter(options, dashboardClientMock.Object, processWrapper: mockProcess.Object);
-            var mutationTree = JsonReportTestHelper.CreateProjectWith();
+            var mutationTree = ReportTestHelper.CreateProjectWith();
 
             reporter.OnAllMutantsTested(mutationTree);
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/HtmlReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/HtmlReporterTests.cs
@@ -25,7 +25,7 @@ namespace Stryker.Core.UnitTest.Reporters
             };
             var reporter = new HtmlReporter(options, mockFileSystem, processWrapper: mockProcess.Object);
 
-            reporter.OnAllMutantsTested(JsonReportTestHelper.CreateProjectWith());
+            reporter.OnAllMutantsTested(ReportTestHelper.CreateProjectWith());
             var reportPath = Path.Combine(options.ReportPath, "mutation-report.html");
             mockFileSystem.FileExists(reportPath).ShouldBeTrue($"Path {reportPath} should exist but it does not.");
         }
@@ -43,7 +43,7 @@ namespace Stryker.Core.UnitTest.Reporters
             };
             var reporter = new HtmlReporter(options, mockFileSystem, processWrapper: mockProcess.Object);
 
-            reporter.OnAllMutantsTested(JsonReportTestHelper.CreateProjectWith());
+            reporter.OnAllMutantsTested(ReportTestHelper.CreateProjectWith());
             var reportPath = Path.Combine(options.ReportPath, "mutation-report.html");
 
             var fileContents = mockFileSystem.GetFile(reportPath).TextContents;
@@ -66,7 +66,7 @@ namespace Stryker.Core.UnitTest.Reporters
             };
             var reporter = new HtmlReporter(options, mockFileSystem, processWrapper: mockProcess.Object);
 
-            reporter.OnAllMutantsTested(JsonReportTestHelper.CreateProjectWith());
+            reporter.OnAllMutantsTested(ReportTestHelper.CreateProjectWith());
             var reportPath = Path.Combine(options.ReportPath, "mutation-report.html");
 
             var fileContents = mockFileSystem.GetFile(reportPath).TextContents;
@@ -88,7 +88,7 @@ namespace Stryker.Core.UnitTest.Reporters
                 ReportFileName = "mutation-report"
             };
             var reporter = new HtmlReporter(options, mockFileSystem, processWrapper: mockProcess.Object);
-            var mutationTree = JsonReportTestHelper.CreateProjectWith();
+            var mutationTree = ReportTestHelper.CreateProjectWith();
 
             reporter.OnAllMutantsTested(mutationTree);
             var reportPath = Path.Combine(options.ReportPath, "mutation-report.html");
@@ -113,7 +113,7 @@ namespace Stryker.Core.UnitTest.Reporters
             };
 
             var reporter = new HtmlReporter(options, mockFileSystem, processWrapper: mockProcess.Object);
-            var mutationTree = JsonReportTestHelper.CreateProjectWith();
+            var mutationTree = ReportTestHelper.CreateProjectWith();
 
             reporter.OnAllMutantsTested(mutationTree);
 
@@ -138,7 +138,7 @@ namespace Stryker.Core.UnitTest.Reporters
             };
 
             var reporter = new HtmlReporter(options, mockFileSystem, processWrapper: mockProcess.Object);
-            var mutationTree = JsonReportTestHelper.CreateProjectWith();
+            var mutationTree = ReportTestHelper.CreateProjectWith();
 
             reporter.OnAllMutantsTested(mutationTree);
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/JsonReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/JsonReporterTests.cs
@@ -50,7 +50,7 @@ namespace Stryker.Core.UnitTest.Reporters
         [Fact]
         public void JsonReportFileComponent_ShouldHaveLanguageSetToCs()
         {
-            var folderComponent = JsonReportTestHelper.CreateProjectWith();
+            var folderComponent = ReportTestHelper.CreateProjectWith();
             var fileComponent = (CsharpFileLeaf)(folderComponent as CsharpFolderComposite).GetAllFiles().First();
 
             new SourceFile(fileComponent).Language.ShouldBe("cs");
@@ -59,7 +59,7 @@ namespace Stryker.Core.UnitTest.Reporters
         [Fact]
         public void JsonReportFileComponent_ShouldContainOriginalSource()
         {
-            var folderComponent = JsonReportTestHelper.CreateProjectWith();
+            var folderComponent = ReportTestHelper.CreateProjectWith();
             var fileComponent = (CsharpFileLeaf)(folderComponent as CsharpFolderComposite).GetAllFiles().First();
 
             new SourceFile(fileComponent).Source.ShouldBe(fileComponent.SourceCode);
@@ -68,7 +68,7 @@ namespace Stryker.Core.UnitTest.Reporters
         [Fact]
         public void JsonReportFileComponents_ShouldContainMutants()
         {
-            var folderComponent = JsonReportTestHelper.CreateProjectWith();
+            var folderComponent = ReportTestHelper.CreateProjectWith();
             foreach (var file in (folderComponent as CsharpFolderComposite).GetAllFiles())
             {
                 var jsonReportComponent = new SourceFile(((CsharpFileLeaf)file));
@@ -83,7 +83,7 @@ namespace Stryker.Core.UnitTest.Reporters
         public void JsonReportFileComponent_DoesNotContainDuplicateMutants()
         {
             var loggerMock = Mock.Of<ILogger>();
-            var folderComponent = JsonReportTestHelper.CreateProjectWith(duplicateMutant: true);
+            var folderComponent = ReportTestHelper.CreateProjectWith(duplicateMutant: true);
             foreach (var file in (folderComponent as CsharpFolderComposite).GetAllFiles())
             {
                 var jsonReportComponent = new SourceFile(((CsharpFileLeaf)file), loggerMock);
@@ -97,7 +97,7 @@ namespace Stryker.Core.UnitTest.Reporters
         [Fact]
         public void JsonReport_ThresholdsAreSet()
         {
-            var folderComponent = JsonReportTestHelper.CreateProjectWith();
+            var folderComponent = ReportTestHelper.CreateProjectWith();
 
             var report = JsonReport.Build(new StrykerOptions(), folderComponent);
 
@@ -109,7 +109,7 @@ namespace Stryker.Core.UnitTest.Reporters
         [Fact]
         public void JsonReport_ShouldContainAtLeastOneFile()
         {
-            var folderComponent = JsonReportTestHelper.CreateProjectWith();
+            var folderComponent = ReportTestHelper.CreateProjectWith();
 
             var report = JsonReport.Build(new StrykerOptions(), folderComponent);
 
@@ -119,7 +119,7 @@ namespace Stryker.Core.UnitTest.Reporters
         [Fact]
         public void JsonReport_ShouldContainTheProjectRoot()
         {
-            var folderComponent = JsonReportTestHelper.CreateProjectWith();
+            var folderComponent = ReportTestHelper.CreateProjectWith();
 
             var report = JsonReport.Build(new StrykerOptions(), folderComponent);
 
@@ -138,7 +138,7 @@ namespace Stryker.Core.UnitTest.Reporters
             };
             var reporter = new JsonReporter(options, mockFileSystem);
 
-            reporter.OnAllMutantsTested(JsonReportTestHelper.CreateProjectWith());
+            reporter.OnAllMutantsTested(ReportTestHelper.CreateProjectWith());
             var reportPath = Path.Combine(options.ReportPath, "mutation-report.json");
             mockFileSystem.FileExists(reportPath).ShouldBeTrue($"Path {reportPath} should exist but it does not.");
             var fileContents = mockFileSystem.File.ReadAllText(reportPath);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/MarkdownSummaryReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/MarkdownSummaryReporterTests.cs
@@ -3,6 +3,7 @@ using System.IO.Abstractions.TestingHelpers;
 using Shouldly;
 using Spectre.Console.Testing;
 using Stryker.Core.Options;
+using Stryker.Core.ProjectComponents;
 using Stryker.Core.Reporters;
 using Xunit;
 
@@ -117,6 +118,29 @@ namespace Stryker.Core.UnitTest.Reporters
             var expectedSummaryReportPath = $"{Path.Join(options.ReportPath, options.ReportFileName)}.md".Replace("\\", "/");
             console.Output.ShouldContain(expectedSummaryReportPath);
             console.Output.GreenSpanCount().ShouldBe(2);
+        }
+
+        [Fact]
+        public void MarkdownSummaryReporter_ShouldNotOutputForEmptyProject()
+        {
+            // Arrange
+            var options = new StrykerOptions
+            {
+                Thresholds = new Thresholds { High = 75, Low = 50, Break = 10 },
+                OutputPath = Directory.GetCurrentDirectory(),
+                ReportFileName = "mutation-summary"
+            };
+            var mockFileSystem = new MockFileSystem();
+            var console = new TestConsole().EmitAnsiSequences().Width(160);
+
+            var reportGenerator = new MarkdownSummaryReporter(options, mockFileSystem, console);
+            var emptyReport = new CsharpFolderComposite() { FullPath = "/home/user/src/project/", RelativePath = "" };
+
+            // Act
+            reportGenerator.OnAllMutantsTested(emptyReport);
+
+            // Assert
+            mockFileSystem.AllFiles.ShouldBeEmpty();
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/MarkdownSummaryReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/MarkdownSummaryReporterTests.cs
@@ -91,7 +91,7 @@ namespace Stryker.Core.UnitTest.Reporters
             foreach(var file in files)
             {
                 var escapedFilename = file.RelativePath.Replace("/", "\\/");
-                stippedFileContents.ShouldContain($"|{escapedFilename}|{file.GetMutationScore() * 100:N2}|");
+                stippedFileContents.ShouldContain($"|{escapedFilename}|{file.GetMutationScore() * 100:N2}%|");
             }
         }
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/MarkdownSummaryReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/MarkdownSummaryReporterTests.cs
@@ -85,7 +85,7 @@ namespace Stryker.Core.UnitTest.Reporters
             var reportPath = Path.Combine(options.ReportPath, "mutation-summary.md");
             var fileContents = mockFileSystem.File.ReadAllText(reportPath);
 
-            // Spaces are variable - remove them for this comparison.
+            // Spaces are unpredictable - remove them for this comparison.
             var stippedFileContents = fileContents.Replace(" ", string.Empty);
 
             foreach(var file in files)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/MarkdownSummaryReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/MarkdownSummaryReporterTests.cs
@@ -1,0 +1,122 @@
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using Shouldly;
+using Spectre.Console.Testing;
+using Stryker.Core.Options;
+using Stryker.Core.Reporters;
+using Xunit;
+
+namespace Stryker.Core.UnitTest.Reporters
+{
+    public class MarkdownSummaryReporterTests : TestBase
+    {
+        [Fact]
+        public void MarkdownSummaryReporter_ShouldGenerateReportOnReportDone()
+        {
+            // Arrange
+            var options = new StrykerOptions
+            {
+                Thresholds = new Thresholds { High = 75, Low = 50, Break = 10 },
+                OutputPath = Directory.GetCurrentDirectory(),
+                ReportFileName = "mutation-summary"
+            };
+            var mockFileSystem = new MockFileSystem();
+            var console = new TestConsole().EmitAnsiSequences().Width(160);
+
+            var reportGenerator = new MarkdownSummaryReporter(options, mockFileSystem, console);
+
+            // Act
+            reportGenerator.OnAllMutantsTested(ReportTestHelper.CreateProjectWith());
+
+            // Assert
+            var reportPath = Path.Combine(options.ReportPath, "mutation-summary.md");
+            mockFileSystem.FileExists(reportPath).ShouldBeTrue($"Path {reportPath} should exist but it does not.");
+        }
+
+        [Fact]
+        public void MarkdownSummaryReporter_ShouldReportCorrectThresholds()
+        {
+            // Arrange
+            var options = new StrykerOptions
+            {
+                Thresholds = new Thresholds { High = 75, Low = 50, Break = 10 },
+                OutputPath = Directory.GetCurrentDirectory(),
+                ReportFileName = "mutation-summary"
+            };
+            var mockFileSystem = new MockFileSystem();
+            var console = new TestConsole().EmitAnsiSequences().Width(160);
+
+            var reportGenerator = new MarkdownSummaryReporter(options, mockFileSystem, console);
+
+            // Act
+            reportGenerator.OnAllMutantsTested(ReportTestHelper.CreateProjectWith());
+
+            // Assert
+            var reportPath = Path.Combine(options.ReportPath, "mutation-summary.md");
+            var fileContents = mockFileSystem.File.ReadAllText(reportPath);
+
+            fileContents.ShouldContain("high:75");
+            fileContents.ShouldContain("low:50");
+            fileContents.ShouldContain("break:10");
+        }
+
+        [Fact]
+        public void MarkdownSummaryReporter_ShouldReportCorrectMutationCoverageValues()
+        {
+            // Arrange
+            var options = new StrykerOptions
+            {
+                Thresholds = new Thresholds { High = 75, Low = 50, Break = 10 },
+                OutputPath = Directory.GetCurrentDirectory(),
+                ReportFileName = "mutation-summary"
+            };
+            var mockFileSystem = new MockFileSystem();
+            var console = new TestConsole().EmitAnsiSequences().Width(160);
+
+            var reportGenerator = new MarkdownSummaryReporter(options, mockFileSystem, console);
+            var mockReport = ReportTestHelper.CreateProjectWith();
+
+            // Act
+            reportGenerator.OnAllMutantsTested(mockReport);
+
+            // Assert
+            var files = mockReport.GetAllFiles();
+            var reportPath = Path.Combine(options.ReportPath, "mutation-summary.md");
+            var fileContents = mockFileSystem.File.ReadAllText(reportPath);
+
+            // Spaces are variable - remove them for this comparison.
+            var stippedFileContents = fileContents.Replace(" ", string.Empty);
+
+            foreach(var file in files)
+            {
+                var escapedFilename = file.RelativePath.Replace("/", "\\/");
+                stippedFileContents.ShouldContain($"|{escapedFilename}|{file.GetMutationScore() * 100:N2}|");
+            }
+        }
+
+        [Fact]
+        public void MarkdownSummaryReporter_ShouldOutputSummaryLocationToTheConsole()
+        {
+            // Arrange
+            var options = new StrykerOptions
+            {
+                Thresholds = new Thresholds { High = 75, Low = 50, Break = 10 },
+                OutputPath = Directory.GetCurrentDirectory(),
+                ReportFileName = "mutation-summary"
+            };
+            var mockFileSystem = new MockFileSystem();
+            var console = new TestConsole().EmitAnsiSequences().Width(160);
+
+            var reportGenerator = new MarkdownSummaryReporter(options, mockFileSystem, console);
+            var mockReport = ReportTestHelper.CreateProjectWith();
+
+            // Act
+            reportGenerator.OnAllMutantsTested(mockReport);
+
+            // Assert
+            var expectedSummaryReportPath = $"{Path.Join(options.ReportPath, options.ReportFileName)}.md".Replace("\\", "/");
+            console.Output.ShouldContain(expectedSummaryReportPath);
+            console.Output.GreenSpanCount().ShouldBe(2);
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReportTestHelper.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReportTestHelper.cs
@@ -8,7 +8,7 @@ using Stryker.Core.ProjectComponents;
 
 namespace Stryker.Core.UnitTest.Reporters
 {
-    public static class JsonReportTestHelper
+    public static class ReportTestHelper
     {
         public static IProjectComponent CreateProjectWith(bool duplicateMutant = false, int mutationScore = 60)
         {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReporterFactoryTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReporterFactoryTests.cs
@@ -50,7 +50,7 @@ namespace Stryker.Core.UnitTest.Reporters
             broadcastReporter.Reporters.ShouldContain(r => r is MarkdownSummaryReporter);
             broadcastReporter.Reporters.ShouldContain(r => r is BaselineReporter);
 
-            result.Reporters.Count().ShouldBe(8);
+            result.Reporters.Count().ShouldBe(9);
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReporterFactoryTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReporterFactoryTests.cs
@@ -47,6 +47,7 @@ namespace Stryker.Core.UnitTest.Reporters
             broadcastReporter.Reporters.ShouldContain(r => r is ClearTextTreeReporter);
             broadcastReporter.Reporters.ShouldContain(r => r is ProgressReporter);
             broadcastReporter.Reporters.ShouldContain(r => r is DashboardReporter);
+            broadcastReporter.Reporters.ShouldContain(r => r is MarkdownSummaryReporter);
             broadcastReporter.Reporters.ShouldContain(r => r is BaselineReporter);
 
             result.Reporters.Count().ShouldBe(8);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/packages.lock.json
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/packages.lock.json
@@ -166,6 +166,11 @@
         "resolved": "5.0.0",
         "contentHash": "iHoYXA0VaSQUONGENB1aVafjDDZDZpwu39MtaRCTrmwFW/cTcK0b2yKNVYneFHJMc3ChtsSoM9lNtJ1dYXkHfA=="
       },
+      "Grynwald.MarkdownGenerator": {
+        "type": "Transitive",
+        "resolved": "2.5.34",
+        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+      },
       "LibGit2Sharp": {
         "type": "Transitive",
         "resolved": "0.27.0-preview-0182",
@@ -1686,6 +1691,7 @@
           "Buildalyzer": "[4.1.4, )",
           "DotNet.Glob": "[3.1.3, )",
           "FSharp.Compiler.Service": "[38.0.0, )",
+          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "LibGit2Sharp": "[0.27.0-preview-0182, )",
           "Microsoft.CodeAnalysis.CSharp": "[4.2.0, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
@@ -1705,8 +1711,8 @@
           "ShellProgressBar": "[5.2.0, )",
           "Spectre.Console": "[0.44.0, )",
           "Spectre.Console.Analyzer": "[0.44.0, )",
-          "Stryker.DataCollector": "[2.1.2, )",
-          "Stryker.RegexMutators": "[2.1.2, )",
+          "Stryker.DataCollector": "[1.0.0, )",
+          "Stryker.RegexMutators": "[1.0.0, )",
           "System.IO.Abstractions": "[17.0.24, )",
           "System.Net.Http.Json": "[6.0.0, )"
         }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/packages.lock.json
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/packages.lock.json
@@ -68,11 +68,11 @@
       },
       "System.IO.Abstractions.TestingHelpers": {
         "type": "Direct",
-        "requested": "[17.0.24, )",
-        "resolved": "17.0.24",
-        "contentHash": "PePTkh5aFsCWSUmc3msyRdJS+aJ15DZDmhgnnjuR7lBSfEyeOi3+CfQqpU28+lpmLH1tFv16K2ODcUNg7lzOPA==",
+        "requested": "[17.1.1, )",
+        "resolved": "17.1.1",
+        "contentHash": "IXsc9skbI+xsjgfsIH5xTdXN/QUyeBc1WVjiJ+IwOthFakBZmN2bqwPH/tYX0FeOEzJ6ZfrZyhqdJ/B+rPHLEQ==",
         "dependencies": {
-          "System.IO.Abstractions": "17.0.24"
+          "System.IO.Abstractions": "17.1.1"
         }
       },
       "xunit": {
@@ -1051,8 +1051,8 @@
       },
       "System.IO.Abstractions": {
         "type": "Transitive",
-        "resolved": "17.0.24",
-        "contentHash": "hA7bacntMiZv1Yf9xtjwl/GP3GT1mG84QxhAk7ijAUD0pJhJaVVwXScE13vMpXnNtlaRDW6SeyZdWg2j2qrh4w=="
+        "resolved": "17.1.1",
+        "contentHash": "LWOM12Bd0kp/gaH4g1o/O2/6JDcHF/fuctF1IqDZt0aAqU2BwGiMihi9Cdcm5jJz8La1wFWbRPuRui8WeX6m8w=="
       },
       "System.IO.FileSystem": {
         "type": "Transitive",
@@ -1707,7 +1707,7 @@
           "Spectre.Console.Analyzer": "[0.44.0, )",
           "Stryker.DataCollector": "[2.1.2, )",
           "Stryker.RegexMutators": "[2.1.2, )",
-          "System.IO.Abstractions": "[17.0.24, )",
+          "System.IO.Abstractions": "[17.1.1, )",
           "System.Net.Http.Json": "[6.0.0, )"
         }
       },

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -41,7 +42,9 @@ namespace Stryker.Core.Initialisation
         private readonly IInitialTestProcess _initialTestProcess;
         private readonly IAssemblyReferenceResolver _assemblyReferenceResolver;
         private ITestRunner _testRunner;
+        private ProjectInfo _projectInfo;
         private readonly ILogger _logger;
+       
 
         public InitialisationProcess(
             IInputFileResolver inputFileResolver = null,
@@ -61,16 +64,16 @@ namespace Stryker.Core.Initialisation
         public MutationTestInput Initialize(StrykerOptions options)
         {
             // resolve project info
-            var projectInfo = _inputFileResolver.ResolveInput(options);
+             _projectInfo = _inputFileResolver.ResolveInput(options);
 
             // initial build
-            var testProjects = projectInfo.TestProjectAnalyzerResults.ToList();
+            var testProjects = _projectInfo.TestProjectAnalyzerResults.ToList();
             for (var i = 0; i < testProjects.Count; i++)
             {
                 _logger.LogInformation(
                     "Building test project {ProjectFilePath} ({CurrentTestProject}/{OfTotalTestProjects})",
                     testProjects[i].ProjectFilePath, i + 1,
-                    projectInfo.TestProjectAnalyzerResults.Count());
+                    _projectInfo.TestProjectAnalyzerResults.Count());
 
                 _initialBuildProcess.InitialBuild(
                     testProjects[i].TargetsFullFramework(),
@@ -79,26 +82,59 @@ namespace Stryker.Core.Initialisation
                     options.MsBuildPath);
             }
 
-            InitializeDashboardProjectInformation(options, projectInfo);
+            InitializeDashboardProjectInformation(options, _projectInfo);
 
             if (_testRunner == null)
             {
-                _testRunner = new VsTestRunnerPool(options, projectInfo);
+                _testRunner = new VsTestRunnerPool(options, _projectInfo);
             }
 
             var input = new MutationTestInput
             {
-                ProjectInfo = projectInfo,
-                AssemblyReferences = _assemblyReferenceResolver.LoadProjectReferences(projectInfo.ProjectUnderTestAnalyzerResult.References).ToList(),
+                ProjectInfo = _projectInfo,
+                AssemblyReferences = _assemblyReferenceResolver.LoadProjectReferences(_projectInfo.ProjectUnderTestAnalyzerResult.References).ToList(),
                 TestRunner = _testRunner,
             };
 
             return input;
         }
 
-        public InitialTestRun InitialTest(StrykerOptions options) =>
+        public InitialTestRun InitialTest(StrykerOptions options)
+        {
             // initial test
-            _initialTestProcess.InitialTest(options, _testRunner);
+            var result = _initialTestProcess.InitialTest(options, _testRunner);
+
+            if (_testRunner.DiscoverTests().Count != 0)
+            {
+                return result;
+            }
+            // no test have been discovered, diagnose this
+            DiagnoseLackOfDetectedTest(_projectInfo);
+            throw new InputException("No test has been detected. Make sure your test project contains test and is compatible with VsTest.");
+        }
+
+        private static readonly Dictionary<string, string> TestFrameworks = new()
+        {
+            ["xunit.core"] = "xunit.runner.visualstudio",
+            ["nunit.framework"] = "NUnit3.TestAdapter",
+            ["Microsoft.VisualStudio.TestPlatform.TestFramework"] = "Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter"
+        };
+
+        public static void DiagnoseLackOfDetectedTest(ProjectInfo projectInfo)
+        {
+            foreach (var testProject in projectInfo.TestProjectAnalyzerResults)
+            {
+                foreach (var (framework, adapter) in TestFrameworks)
+                {
+                    if (testProject.References.Any(r => r.Contains(framework)) && !testProject.References.Any(r => r.Contains(adapter)))
+                    {
+                        throw new InputException($"Project '{testProject.ProjectFilePath}' is not supported by VsTest because it is missing an appropriate VstTest adapter for '{framework}'. " +
+                            $"Adding '{adapter}' to this project references may resolve the issue.");
+                    }
+                }
+            }
+        }
+
 
         private void InitializeDashboardProjectInformation(StrykerOptions options, ProjectInfo projectInfo)
         {

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -149,7 +149,7 @@ namespace Stryker.Core.Initialisation
             return projectUnderTestPath;
         }
 
-        private void ValidateTestProjectsCanBeExecuted(ProjectInfo projectInfo)
+        private static void ValidateTestProjectsCanBeExecuted(ProjectInfo projectInfo)
         {
             // if references contains Microsoft.VisualStudio.QualityTools.UnitTestFramework 
             // we have detected usage of mstest V1 and should exit

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
@@ -13,12 +13,10 @@ namespace Stryker.Core.Initialisation
 
         public ProjectInfo() : this(null) { }
 
-        public ProjectInfo(IFileSystem fileSystem)
-        {
-            _fileSystem = fileSystem ?? new FileSystem();
-        }
+        public ProjectInfo(IFileSystem fileSystem) => _fileSystem = fileSystem ?? new FileSystem();
 
         public IEnumerable<IAnalyzerResult> TestProjectAnalyzerResults { get; set; }
+
         public IAnalyzerResult ProjectUnderTestAnalyzerResult { get; set; }
 
         /// <summary>
@@ -26,12 +24,9 @@ namespace Stryker.Core.Initialisation
         /// </summary>
         public IProjectComponent ProjectContents { get; set; }
 
-        public string GetInjectionFilePath(IAnalyzerResult analyzerResult)
-        {
-            return Path.Combine(
+        public string GetInjectionFilePath(IAnalyzerResult analyzerResult) => Path.Combine(
                 Path.GetDirectoryName(analyzerResult.GetAssemblyPath()),
                 Path.GetFileName(ProjectUnderTestAnalyzerResult.GetAssemblyPath()));
-        }
 
         public virtual void RestoreOriginalAssembly()
         {
@@ -41,6 +36,7 @@ namespace Stryker.Core.Initialisation
                 _fileSystem.File.Copy(GetBackupName(injectionPath), injectionPath, true);
             }
         }
+
         public virtual void BackupOriginalAssembly()
         {
             foreach (var testProject in TestProjectAnalyzerResults)

--- a/src/Stryker.Core/Stryker.Core/Reporters/MarkdownSummaryReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/MarkdownSummaryReporter.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Text;
+using Grynwald.MarkdownGenerator;
+using Microsoft.Extensions.Options;
+using Spectre.Console;
+using Stryker.Core.Mutants;
+using Stryker.Core.Options;
+using Stryker.Core.ProjectComponents;
+
+namespace Stryker.Core.Reporters
+{
+    /// <summary>
+    /// Markdown result table reporter.
+    /// </summary>
+    public class MarkdownSummaryReporter : IReporter
+    {
+        private readonly StrykerOptions _options;
+        private readonly IAnsiConsole _console;
+        private readonly IFileSystem _fileSystem;
+
+        public MarkdownSummaryReporter(StrykerOptions strykerOptions, IFileSystem fileSystem = null, IAnsiConsole console = null)
+        {
+            _options = strykerOptions;
+            _console = console ?? AnsiConsole.Console;
+            _fileSystem = fileSystem ?? new FileSystem();
+        }
+
+        public void OnStartMutantTestRun(IEnumerable<IReadOnlyMutant> mutantsToBeTested)
+        {
+            // This reporter does not report during the testrun
+        }
+
+        public void OnMutantsCreated(IReadOnlyProjectComponent reportComponent)
+        {
+            // This reporter does not report during the testrun
+        }
+
+        public void OnMutantTested(IReadOnlyMutant result)
+        {
+            // This reporter does not report during the testrun
+        }
+
+        public void OnAllMutantsTested(IReadOnlyProjectComponent reportComponent)
+        {
+            var files = reportComponent.GetAllFiles();
+            if (files.Any())
+            {
+                var filename = _options.ReportFileName + ".md";
+                var reportPath = Path.Combine(_options.ReportPath, filename);
+                var reportUri = "file://" + reportPath.Replace("\\", "/");
+
+                GenerateMarkdownReport(_options, reportPath, files);
+
+                _console.WriteLine();
+                _console.MarkupLine("[Green]Your Markdown summary has been generated at:[/]");
+
+                if (_console.Profile.Capabilities.Links)
+                {
+                    // We must print the report path as the link text because on some terminals links might be supported but not actually clickable: https://github.com/spectreconsole/spectre.console/issues/764
+                    _console.MarkupLineInterpolated($"[Green][link={reportUri}]{reportPath}[/][/]");
+                }
+                else
+                {
+                    _console.MarkupLineInterpolated($"[Green]{reportUri}[/]");
+                }
+            }
+        }
+
+        private void GenerateMarkdownReport(StrykerOptions options, string reportPath, IEnumerable<IFileLeaf> files)
+        {
+            if (!files.Any())
+            {
+                return;
+            }
+
+            var mdSummaryDocument = new MdDocument();
+            mdSummaryDocument.Root.Add(new MdHeading(2, "Mutation Testing Summary"));
+
+            var mdSummary = new MdTable(new MdTableRow(new[] { "File", "% score", "# killed", "# timeout", "# survived", "# no cov", "# error" }));
+
+            foreach (var file in files)
+            {
+                mdSummary.Add(GenerateFileData(file));
+            }
+
+            mdSummaryDocument.Root.Add(mdSummary);
+            mdSummaryDocument.Root.Add(new MdHeading(4, new MdEmphasisSpan($"Coverage Thresholds: high:{_options.Thresholds.High} low:{_options.Thresholds.Low} break:{_options.Thresholds.Break}")));
+
+            _fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(reportPath));
+            using var mdFile = _fileSystem.File.Create(reportPath);
+            mdSummaryDocument.Save(mdFile);
+        }
+
+        private MdTableRow GenerateFileData(IFileLeaf fileScores)
+        {
+            var values = new List<string>();
+
+            values.Add(fileScores.RelativePath ?? "All files");
+
+            var mutationScore = fileScores.GetMutationScore();
+
+            if (fileScores.IsComponentExcluded(_options.Mutate))
+            {
+                values.Add("Excluded");
+            }
+            else if (double.IsNaN(mutationScore))
+            {
+                values.Add("N/A");
+            }
+            else
+            {
+                values.Add($"{mutationScore * 100:N2}");
+            }
+
+            var mutants = fileScores.Mutants.ToList();
+
+            values.Add(mutants.Count(m => m.ResultStatus == MutantStatus.Killed).ToString());
+            values.Add(mutants.Count(m => m.ResultStatus == MutantStatus.Timeout).ToString());
+            values.Add((fileScores.TotalMutants().Count() - fileScores.DetectedMutants().Count()).ToString());
+            values.Add(mutants.Count(m => m.ResultStatus == MutantStatus.NoCoverage).ToString());
+            values.Add(mutants.Count(m => m.ResultStatus == MutantStatus.CompileError).ToString());
+
+            return new MdTableRow(values);
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Reporters/MarkdownSummaryReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/MarkdownSummaryReporter.cs
@@ -90,7 +90,7 @@ namespace Stryker.Core.Reporters
                     "Survived",
                     "Timeout",
                     "No Coverage",
-                    "Ingnored",
+                    "Ignored",
                     "Compile Errors",
                     "Total Detected",
                     "Total Undetected",

--- a/src/Stryker.Core/Stryker.Core/Reporters/MarkdownSummaryReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/MarkdownSummaryReporter.cs
@@ -2,15 +2,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
-using System.Text;
 using Grynwald.MarkdownGenerator;
-using Microsoft.Extensions.Options;
 using Spectre.Console;
 using Stryker.Core.Mutants;
-using Stryker.Core.Mutators;
 using Stryker.Core.Options;
 using Stryker.Core.ProjectComponents;
-using static FSharp.Compiler.AbstractIL.IL.ILExceptionClause;
 
 namespace Stryker.Core.Reporters
 {

--- a/src/Stryker.Core/Stryker.Core/Reporters/Reporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Reporter.cs
@@ -10,6 +10,7 @@ namespace Stryker.Core.Reporters
         Json,
         Html,
         Dashboard,
+        Markdown,
         Baseline
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Reporters/ReporterFactory.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/ReporterFactory.cs
@@ -31,6 +31,7 @@ namespace Stryker.Core.Reporters
                 { Reporter.Json, new JsonReporter(options) },
                 { Reporter.Html, new Html.reporter.HtmlReporter(options) },
                 { Reporter.Dashboard, new DashboardReporter(options) },
+                { Reporter.Markdown, new MarkdownSummaryReporter(options) },
                 { Reporter.Baseline, new BaselineReporter(options) }
             };
         }

--- a/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
+++ b/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
@@ -37,6 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Grynwald.MarkdownGenerator" Version="2.5.34" />
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0182" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
     <PackageReference Include="FSharp.Compiler.Service" Version="38.0.0" />

--- a/src/Stryker.Core/Stryker.Core/libman.json
+++ b/src/Stryker.Core/Stryker.Core/libman.json
@@ -3,7 +3,7 @@
   "defaultProvider": "jsdelivr",
   "libraries": [
     {
-      "library": "mutation-testing-elements@1.7.6",
+      "library": "mutation-testing-elements@1.7.10",
       "files": [
         "dist/mutation-test-elements.js"
       ],

--- a/src/Stryker.Core/Stryker.Core/packages.lock.json
+++ b/src/Stryker.Core/Stryker.Core/packages.lock.json
@@ -219,9 +219,9 @@
       },
       "System.IO.Abstractions": {
         "type": "Direct",
-        "requested": "[17.0.24, )",
-        "resolved": "17.0.24",
-        "contentHash": "hA7bacntMiZv1Yf9xtjwl/GP3GT1mG84QxhAk7ijAUD0pJhJaVVwXScE13vMpXnNtlaRDW6SeyZdWg2j2qrh4w=="
+        "requested": "[17.1.1, )",
+        "resolved": "17.1.1",
+        "contentHash": "LWOM12Bd0kp/gaH4g1o/O2/6JDcHF/fuctF1IqDZt0aAqU2BwGiMihi9Cdcm5jJz8La1wFWbRPuRui8WeX6m8w=="
       },
       "System.Net.Http.Json": {
         "type": "Direct",

--- a/src/Stryker.Core/Stryker.Core/packages.lock.json
+++ b/src/Stryker.Core/Stryker.Core/packages.lock.json
@@ -49,6 +49,12 @@
           "FSharp.Core": "[5.0.0]"
         }
       },
+      "Grynwald.MarkdownGenerator": {
+        "type": "Direct",
+        "requested": "[2.5.34, )",
+        "resolved": "2.5.34",
+        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+      },
       "LibGit2Sharp": {
         "type": "Direct",
         "requested": "[0.27.0-preview-0182, )",


### PR DESCRIPTION
A proposed implementation of 
https://github.com/stryker-mutator/stryker-net/issues/2133

Creates a summary of the mutation test run in a markdown file:

```bash
dotnet stryker --reporter "markdown"
```
e.g.

## Mutation Testing Summary

| File                                                        | % score | \# killed | \# timeout | \# survived | \# no cov | \# error |
| ----------------------------------------------------------- | ------- | --------- | ---------- | ----------- | --------- | -------- |
| Entities\\Entity1.cs                          | 100.00  | 1         | 0          | 3           | 0         | 2        |
| Program.cs                                                  | N\/A    | 0         | 0          | 6           | 0         | 0        |
| Utils\\EntityExtensions.cs                       | 87.50   | 7         | 0          | 1           | 1         | 0        |

#### *Coverage Thresholds: high:90 low:60 break:60*

This is my first contribution (I'm a huge fan of what you're doing on this project) - is there anything I've missed?  I daresay my coding style needs some work to match what you already have.  Happy to make any changes.  This will enable a scenario where we can add this report to PRs as a comment allowing us to easily see the real test coverage values.
